### PR TITLE
Updates for 5.6 and php 5.4

### DIFF
--- a/packages/reviews/CHANGELOG
+++ b/packages/reviews/CHANGELOG
@@ -1,3 +1,4 @@
+1.4.1dev - Updates for concrete5.6 and php 5.4
 1.4 - Fixed star rating calculation when block is added from page defaults, global areas and stacks
 
 1.3 - Updated add/edit ui for 5.5 + minor code cleanup.

--- a/packages/reviews/blocks/reviews/controller.php
+++ b/packages/reviews/blocks/reviews/controller.php
@@ -46,6 +46,10 @@ class ReviewsBlockController extends BlockController {
 		$this->addHeaderItem($html->css('jquery.ui.css'));
 		$this->addHeaderItem($html->css('jquery.rating.css'));	
 	}	
+
+	public function view() {
+		$this->set('Entry', new ReviewsBlockEntry($this->bID));
+	}
 		
 	function delete() {
 		$ip = Loader::helper('validation/ip');

--- a/packages/reviews/blocks/reviews/view.php
+++ b/packages/reviews/blocks/reviews/view.php
@@ -87,7 +87,7 @@ div.guestBook-entry {
 	<?php 
 	$u = new User();
 	$posts = $controller->getEntries();
-	$bp = $controller->getPermissionsObject(); 
+	$bp = $controller->getPermissionObject(); 
 	foreach($posts as $p) { ?>
 		<?php  if($p['approved'] || $bp->canWrite()) { ?>
 		<div class="guestBook-entry">

--- a/packages/reviews/controller.php
+++ b/packages/reviews/controller.php
@@ -5,8 +5,8 @@ defined('C5_EXECUTE') or die(_("Access Denied."));
 class ReviewsPackage extends Package {
 
 	protected $pkgHandle = 'reviews';
-	protected $appVersionRequired = '5.5';
-	protected $pkgVersion = '1.4';
+	protected $appVersionRequired = '5.6';
+	protected $pkgVersion = '1.4.1dev';
 	
 	public function getPackageDescription() {
 		return t("Adds the ability to add ratings and comments to a page.");


### PR DESCRIPTION
Corrects BlockType::getPermissionsObject() naming change as well as php
5.4 strictness
